### PR TITLE
Fix stopwatch problem when calling a child query or command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- There should always be "Unreleased" section at the beginning. -->
 
 ## Unreleased
+- Fix stopwatch problem when calling a child query/command
 
 ## 1.0.0 - 2021-05-13
 - Initial implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 - Fix stopwatch problem when calling a child query/command
+- Fix profiling used decoders when calling a child query/command
 
 ## 1.0.0 - 2021-05-13
 - Initial implementation

--- a/src/CommandSender.php
+++ b/src/CommandSender.php
@@ -184,7 +184,7 @@ class CommandSender implements CommandSenderInterface
                 )
             );
 
-            $this->stopwatch = new Stopwatch();
+            $this->stopwatch = $this->stopwatch ?? new Stopwatch();
             $this->stopwatch->start($key->toString());
         }
 

--- a/src/CommandSender.php
+++ b/src/CommandSender.php
@@ -117,7 +117,7 @@ class CommandSender implements CommandSenderInterface
                 );
 
                 if ($this->isHandled && $this->lastError === null) {
-                    $this->decodeResponse();
+                    $this->decodeResponse($currentProfileKey);
                 }
 
                 if ($this->isHandled && $command instanceof ProfileableInterface) {
@@ -197,22 +197,22 @@ class CommandSender implements CommandSenderInterface
         ?UuidInterface $currentProfilerKey,
         SendCommandHandlerInterface $currentHandler
     ): void {
-        if ($this->profilerBag && $currentProfilerKey && ($item = $this->profilerBag->get($currentProfilerKey))) {
+        if ($this->profilerBag && $currentProfilerKey && ($profilerItem = $this->profilerBag->get($currentProfilerKey))) {
             if ($this->stopwatch) {
                 $elapsed = $this->stopwatch->stop($currentProfilerKey->toString());
 
-                $item->setDuration((int) $elapsed->getDuration());
+                $profilerItem->setDuration((int) $elapsed->getDuration());
             }
 
-            $item->setHandledBy(get_class($currentHandler));
-            $item->setDecodedBy($this->lastUsedDecoders);
+            $profilerItem->setHandledBy(get_class($currentHandler));
+            $profilerItem->setDecodedBy($this->lastUsedDecoders[$currentProfilerKey->toString()]);
 
             if ($this->lastSuccess) {
-                $item->setResponse($this->lastSuccess);
+                $profilerItem->setResponse($this->lastSuccess);
             }
 
             if ($this->lastError) {
-                $item->setError($this->lastError);
+                $profilerItem->setError($this->lastError);
             }
         }
     }

--- a/src/QueryFetcher.php
+++ b/src/QueryFetcher.php
@@ -157,7 +157,7 @@ class QueryFetcher implements QueryFetcherInterface
                 );
 
                 if ($this->isHandled && $this->lastError === null) {
-                    $this->decodeResponse();
+                    $this->decodeResponse($currentProfileKey);
                 }
 
                 if ($this->isHandled && $query instanceof ProfileableInterface) {
@@ -279,7 +279,7 @@ class QueryFetcher implements QueryFetcherInterface
             }
 
             $profilerItem->setHandledBy(get_class($currentHandler));
-            $profilerItem->setDecodedBy($this->lastUsedDecoders);
+            $profilerItem->setDecodedBy($this->lastUsedDecoders[$currentProfilerKey->toString()]);
 
             if ($query instanceof CacheableInterface) {
                 $profilerItem->setCacheKey($query->getCacheKey());

--- a/src/QueryFetcher.php
+++ b/src/QueryFetcher.php
@@ -258,7 +258,7 @@ class QueryFetcher implements QueryFetcherInterface
 
             $this->profilerBag->add($key, $profilerItem);
 
-            $this->stopwatch = new Stopwatch();
+            $this->stopwatch = $this->stopwatch ?? new Stopwatch();
             $this->stopwatch->start($key->toString());
         }
 


### PR DESCRIPTION
This fixes a problem when a consequent query/command is called. 

It otherwise fails on stopwatch->stop event when the first query is finished.

1. start query A (starting stopwatch-A)
2. in decoding of A response start a query B (starting stopwatch-B)
3. when B is decoded and finished -> it stops a stopwatch-B
4. stopwatch doesn't have stopwatch-A event now, since there is only one instance of a QueryFetcher and its stopwatch instance was created always as new (empty)